### PR TITLE
remove 'name' from Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,12 @@ Note that the order of the collection dictates the evaluation order of your rule
 
 ### Creating rules
 
-A [rule](https://github.com/metio/reguloj/blob/main/src/main/java/wtf/metio/reguloj/Rule.java) has a name and runs in a given context. Additionally, it can be checked whether a rule fires in a given context.
+A [rule](https://github.com/metio/reguloj/blob/main/src/main/java/wtf/metio/reguloj/Rule.java) runs in a given context. Additionally, it can be checked whether a rule fires in a given context.
 
 Either implement the `Rule` interface yourself and or use the supplied rule implementation and builder. A standard rule is composed of a `java.util.function.Predicate` and `java.util.function.Consumer`. Both interfaces require you to implement only a single method and do not restrict you in any way. Complex rules can be created by grouping or chaining predicates/consumers together with the help of several utility methods. The following example creates a rule composed of 2 predicates and 2 consumers:
 
 ```java
-Rule<CONTEXT> rule = Rule.called(name)
-                .when(predicate1.and(predicate2))
+Rule<CONTEXT> rule = Rule.when(predicate1.and(predicate2))
                 .then(consumer1.andThen(consumer2));
 
 // true if the rule would fire in the given context, e.g. the above predicate is true.
@@ -59,12 +58,24 @@ rule.fires(context);
 rule.run(context);
 ```
 
-Using Java 8 lambdas is possible as well:
+Using Java 8 lambdas is possible as well, however be aware that some additional type information is required in this case:
 
 ```java
-Rule<CONTEXT> rule = Rule.called(name)
-                .when(context -> context.check())
+Rule<CONTEXT> rule = Rule.<CONTEXT>when(context -> context.check())
                 .then(context -> context.action())
+
+Rule<CONTEXT> rule = Rule.when((CONTEXT context) -> context.check())
+                .then(context -> context.action())
+```
+
+In case you want to create a `Rule` that always fires/runs, use the following shortcut:
+
+```java
+// using predefined consumer
+Rule<CONTEXT> rule = Rule.always(consumer1.andThen(consumer2));
+
+// using lambda
+Rule<CONTEXT> rule = Rule.always((CONTEXT context) -> context.action())
 ```
 
 Note that custom implementations of the `Rule` interface don't necessary have to use the `java.util.function` package and are free to choose how their implementation looks like.

--- a/src/main/java/wtf/metio/reguloj/AbstractContext.java
+++ b/src/main/java/wtf/metio/reguloj/AbstractContext.java
@@ -6,7 +6,7 @@ package wtf.metio.reguloj;
 
 /**
  * Abstract implementation of the {@link Context} interface. Use this class in case you want to extend your context
- * beyond its topic. Otherwise use {@link SimpleContext} to just pass along your topic. Note that this class is only
+ * beyond its topic. Otherwise, use {@link SimpleContext} to just pass along your topic. Note that this class is only
  * marked as abstract (and called like that) because users who just want to pass along a topic should use {@link
  * SimpleContext}.
  *

--- a/src/main/java/wtf/metio/reguloj/AbstractRuleEngine.java
+++ b/src/main/java/wtf/metio/reguloj/AbstractRuleEngine.java
@@ -7,7 +7,7 @@ package wtf.metio.reguloj;
 import java.util.Collection;
 
 /**
- * Abstract rule engine which provides an implementation for the {@link #analyze(Collection, Context)} method. Therefore
+ * Abstract rule engine which provides an implementation for the {@link #analyze(Collection, Context)} method. Therefore,
  * implementors only have to write the {@link #infer(Collection, Context)} method.
  *
  * @param <CONTEXT> The context type.

--- a/src/main/java/wtf/metio/reguloj/FluentRuleBuilder.java
+++ b/src/main/java/wtf/metio/reguloj/FluentRuleBuilder.java
@@ -18,12 +18,6 @@ final class FluentRuleBuilder<CONTEXT extends Context<?>> implements RuleBuilder
     private Predicate<CONTEXT> predicate;
 
     @Override
-    public RuleBuilder<CONTEXT> called(final String newName) {
-        name = newName;
-        return this;
-    }
-
-    @Override
     public RuleBuilder<CONTEXT> when(final Predicate<CONTEXT> newPredicate) {
         predicate = newPredicate;
         return this;
@@ -31,7 +25,7 @@ final class FluentRuleBuilder<CONTEXT extends Context<?>> implements RuleBuilder
 
     @Override
     public Rule<CONTEXT> then(final Consumer<CONTEXT> consumer) {
-        return new JavaUtilFunctionRule<>(name, predicate, consumer);
+        return new JavaUtilFunctionRule<>(predicate, consumer);
     }
 
 }

--- a/src/main/java/wtf/metio/reguloj/JavaUtilFunctionRule.java
+++ b/src/main/java/wtf/metio/reguloj/JavaUtilFunctionRule.java
@@ -15,7 +15,6 @@ import java.util.function.Predicate;
  * @see java.util.function.Consumer
  */
 record JavaUtilFunctionRule<CONTEXT extends Context<?>>(
-        String name,
         Predicate<CONTEXT> predicate,
         Consumer<CONTEXT> consumer) implements Rule<CONTEXT> {
 

--- a/src/main/java/wtf/metio/reguloj/Rule.java
+++ b/src/main/java/wtf/metio/reguloj/Rule.java
@@ -4,6 +4,9 @@
  */
 package wtf.metio.reguloj;
 
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
 /**
  * <p>
  * A {@link Rule} combines {@link java.util.function.Predicate} and {@link java.util.function.Consumer} interfaces and
@@ -45,17 +48,24 @@ package wtf.metio.reguloj;
 public interface Rule<CONTEXT extends Context<?>> {
 
     /**
+     * Start building a new Rule by specifying a Predicate.
+     *
      * @param <CONTEXT> The context type.
      * @return A new builder to construct rules.
      */
-    static <CONTEXT extends Context<?>> RuleBuilder<CONTEXT> called(final String name) {
-        return new FluentRuleBuilder<CONTEXT>().called(name);
+    static <CONTEXT extends Context<?>> RuleBuilder<CONTEXT> when(final Predicate<CONTEXT> predicate) {
+        return new FluentRuleBuilder<CONTEXT>().when(predicate);
     }
 
     /**
-     * @return The human readable name of this rule.
+     * Create a new Rule that always fires/runs and calls the given Consumer.
+     *
+     * @param <CONTEXT> The context type.
+     * @return A new builder to construct rules.
      */
-    String name();
+    static <CONTEXT extends Context<?>> Rule<CONTEXT> always(final Consumer<CONTEXT> consumer) {
+        return new FluentRuleBuilder<CONTEXT>().when(c -> true).then(consumer);
+    }
 
     /**
      * Checks whether this rule would fire for a given context.

--- a/src/main/java/wtf/metio/reguloj/RuleBuilder.java
+++ b/src/main/java/wtf/metio/reguloj/RuleBuilder.java
@@ -13,7 +13,6 @@ import java.util.function.Predicate;
  * Effective Java, Item 2) and offers 3 methods:
  * </p>
  * <ul>
- * <li>{@link #called(String) called}: Use this method to name your new rule.</li>
  * <li>{@link #when(Predicate) when}: Use this method to specify the {@link Predicate} for your new rule.</li>
  * <li>{@link #then(Consumer) then}: Use this method to specify the {@link Consumer} for your new rule.</li>
  * </ul>
@@ -24,11 +23,9 @@ import java.util.function.Predicate;
  * Rule creation with name, predicate and consumer:
  * </p>
  * <pre>
- * String name = "...";
  * Predicate predicate = ...;
  * Consumer consumer = ...;
  * Rule rule = Rule.builder()
- *               .called(<em>name</em>)
  *               .when(<em>predicate</em>)
  *               .then(<em>consumer</em>)
  * </pre>
@@ -44,14 +41,6 @@ import java.util.function.Predicate;
  * @see java.util.function.Consumer
  */
 public interface RuleBuilder<CONTEXT extends Context<?>> {
-
-    /**
-     * Sets the name of the new rule.
-     *
-     * @param name The name to set.
-     * @return The current rule builder.
-     */
-    RuleBuilder<CONTEXT> called(String name);
 
     /**
      * Sets the {@link Predicate} for the new rule.

--- a/src/test/java/wtf/metio/reguloj/FluentRuleBuilderTest.java
+++ b/src/test/java/wtf/metio/reguloj/FluentRuleBuilderTest.java
@@ -15,9 +15,9 @@ final class FluentRuleBuilderTest {
 
     @Test
     void shouldCreateRuleIfAllValuesAreSet() {
-        final var builder = new FluentRuleBuilder<Context<Object>>();
-        builder.called("test rule").when(Mockito.mock(Predicate.class));
-        final var rule = builder.then(Mockito.mock(Consumer.class));
+        final var rule = new FluentRuleBuilder<Context<Object>>()
+                .when(Mockito.mock(Predicate.class))
+                .then(Mockito.mock(Consumer.class));
         Assertions.assertNotNull(rule);
     }
 

--- a/src/test/java/wtf/metio/reguloj/JavaUtilFunctionRuleTest.java
+++ b/src/test/java/wtf/metio/reguloj/JavaUtilFunctionRuleTest.java
@@ -30,49 +30,43 @@ final class JavaUtilFunctionRuleTest {
 
     @Test
     void shouldCreateRuleIfAllValuesAreSet() {
-        final var rule = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
+        final var rule = new JavaUtilFunctionRule<>(predicate, consumer);
         Assertions.assertNotNull(rule);
     }
 
     @Test
     void shouldReturnFalseWhenPremiseDoesNotApply() {
         BDDMockito.given(predicate.test(context)).willReturn(Boolean.FALSE);
-        final var rule = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
+        final var rule = new JavaUtilFunctionRule<>(predicate, consumer);
         Assertions.assertFalse(rule.fires(context));
     }
 
     @Test
     void shouldFireWhenPremiseApplies() {
         BDDMockito.given(predicate.test(context)).willReturn(Boolean.TRUE);
-        final var rule = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
+        final var rule = new JavaUtilFunctionRule<>(predicate, consumer);
         Assertions.assertTrue(rule.fires(context));
     }
 
     @Test
-    void shouldReturnTheSetName() {
-        final var rule = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
-        Assertions.assertEquals(NAME, rule.name());
-    }
-
-    @Test
     void equalsIsReflexive() {
-        final var rule = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
+        final var rule = new JavaUtilFunctionRule<>(predicate, consumer);
         Assertions.assertEquals(rule, rule);
     }
 
     @Test
     void equalsIsSymmetric() {
-        final var rule1 = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
-        final var rule2 = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
+        final var rule1 = new JavaUtilFunctionRule<>(predicate, consumer);
+        final var rule2 = new JavaUtilFunctionRule<>(predicate, consumer);
         Assertions.assertEquals(rule1, rule2);
         Assertions.assertEquals(rule2, rule1);
     }
 
     @Test
     void equalsIsTransitive() {
-        final var rule1 = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
-        final var rule2 = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
-        final var rule3 = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
+        final var rule1 = new JavaUtilFunctionRule<>(predicate, consumer);
+        final var rule2 = new JavaUtilFunctionRule<>(predicate, consumer);
+        final var rule3 = new JavaUtilFunctionRule<>(predicate, consumer);
         Assertions.assertEquals(rule1, rule2);
         Assertions.assertEquals(rule2, rule3);
         Assertions.assertEquals(rule3, rule1);
@@ -80,50 +74,43 @@ final class JavaUtilFunctionRuleTest {
 
     @Test
     void equalsReturnFalseOnNull() {
-        final var rule = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
+        final var rule = new JavaUtilFunctionRule<>(predicate, consumer);
         Assertions.assertNotEquals(null, rule);
     }
 
     @Test
     void equalsReturnFalseOnWrongClass() {
-        final var rule = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
+        final var rule = new JavaUtilFunctionRule<>(predicate, consumer);
         Assertions.assertNotEquals("", rule);
     }
 
     @Test
     void equalsWorks() {
-        final var rule1 = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
+        final var rule1 = new JavaUtilFunctionRule<>(predicate, consumer);
         final var rule2 = rule1;
         Assertions.assertEquals(rule1, rule2);
     }
 
     @Test
-    void equalsWorksWithDifferentNames() {
-        final var rule1 = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
-        final var rule2 = new JavaUtilFunctionRule<>("rule2", predicate, consumer); //$NON-NLS-1$
-        Assertions.assertNotEquals(rule1, rule2);
-    }
-
-    @Test
     void equalsWorksWithDifferentPremises() {
         final var predicate2 = Mockito.mock(Predicate.class);
-        final var rule1 = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
-        final var rule2 = new JavaUtilFunctionRule<>(NAME, predicate2, consumer);
+        final var rule1 = new JavaUtilFunctionRule<>(predicate, consumer);
+        final var rule2 = new JavaUtilFunctionRule<>(predicate2, consumer);
         Assertions.assertNotEquals(rule1, rule2);
     }
 
     @Test
     void equalsWorksWithDifferentConsumer() {
         final var consumer2 = Mockito.mock(Consumer.class);
-        final var rule1 = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
-        final var rule2 = new JavaUtilFunctionRule<>(NAME, predicate, consumer2);
+        final var rule1 = new JavaUtilFunctionRule<>(predicate, consumer);
+        final var rule2 = new JavaUtilFunctionRule<>(predicate, consumer2);
         Assertions.assertNotEquals(rule1, rule2);
     }
 
     @Test
     void hashCodeIsConsistentWithEquals() {
-        final var rule1 = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
-        final var rule2 = new JavaUtilFunctionRule<>(NAME, predicate, consumer);
+        final var rule1 = new JavaUtilFunctionRule<>(predicate, consumer);
+        final var rule2 = new JavaUtilFunctionRule<>(predicate, consumer);
         Assertions.assertEquals(rule1, rule2);
         Assertions.assertEquals(rule1.hashCode(), rule2.hashCode());
     }

--- a/src/test/java/wtf/metio/reguloj/RuleTest.java
+++ b/src/test/java/wtf/metio/reguloj/RuleTest.java
@@ -17,14 +17,13 @@ final class RuleTest {
 
     @Test
     void shouldCreateBuilder() {
-        Assertions.assertNotNull(Rule.called("test"));
+        Assertions.assertNotNull(Rule.when(Mockito.mock(Predicate.class)));
     }
 
     @Test
     void shouldCreateRule() {
-        final var builder = Rule.<Context<Object>>called("test");
-        builder.called(NAME).when(Mockito.mock(Predicate.class));
-        final var rule = builder.then(Mockito.mock(Consumer.class));
+        final var rule = Rule.when(Mockito.mock(Predicate.class))
+                .then(Mockito.mock(Consumer.class));
         Assertions.assertNotNull(rule);
     }
 

--- a/src/test/java/wtf/metio/reguloj/shoppingcart/ShoppingCartTest.java
+++ b/src/test/java/wtf/metio/reguloj/shoppingcart/ShoppingCartTest.java
@@ -26,11 +26,8 @@ class ShoppingCartTest {
 
         @BeforeEach
         void setUp() {
-            final var standardPrice = Rule.<Cart>called("single purchase uses standard price")
-                    .when(cart -> true) // always fires thus can be used as a fallback
-                    .then(cart -> cart.prices().add(new Price(TEST_PRODUCT, 100)));
-            final var reducedPrice = Rule.<Cart>called("multiple purchases get reduced price")
-                    .when(cart -> cart.topic().size() > 1) // only fires for multiple products
+            final var standardPrice = Rule.<Cart>always(cart -> cart.prices().add(new Price(TEST_PRODUCT, 100)));
+            final var reducedPrice = Rule.<Cart>when(cart -> cart.topic().size() > 1) // only fires for multiple products
                     .then(cart -> cart.prices().add(new Price(TEST_PRODUCT, 75 * cart.topic().size())));
             // the order is important here, so we use a List
             rules = List.of(reducedPrice, standardPrice);
@@ -73,11 +70,9 @@ class ShoppingCartTest {
 
         @BeforeEach
         void setUp() {
-            final var standardPrice = Rule.<Cart>called("single purchase uses standard price")
-                    .when(cart -> cart.topic().size() == 1) // fires for single products
+            final var standardPrice = Rule.<Cart>when(cart -> cart.topic().size() == 1) // fires for single products
                     .then(cart -> cart.prices().add(new Price(TEST_PRODUCT, 100)));
-            final var reducedPrice = Rule.<Cart>called("multiple purchases get reduced price")
-                    .when(cart -> cart.topic().size() > 1) // fires for multiple products
+            final var reducedPrice = Rule.<Cart>when(cart -> cart.topic().size() > 1) // fires for multiple products
                     .then(cart -> cart.prices().add(new Price(TEST_PRODUCT, 75 * cart.topic().size())));
             // the order is no longer important
             rules = Set.of(standardPrice, reducedPrice);
@@ -120,13 +115,11 @@ class ShoppingCartTest {
 
         @BeforeEach
         void setUp() {
-            final var standardPrice = Rule.<Cart>called("single purchase uses standard price")
-                    // we need an extra terminal operation to avoid an infinite loop
-                    .when(cart -> cart.topic().size() == 1 && cart.prices().size() == 0)
+            // we need an extra terminal operation to avoid an infinite loop
+            final var standardPrice = Rule.when((Cart cart) -> cart.topic().size() == 1 && cart.prices().size() == 0)
                     .then(cart -> cart.prices().add(new Price(TEST_PRODUCT, 100)));
-            final var reducedPrice = Rule.<Cart>called("multiple purchases get reduced price")
-                    // we need an extra terminal operation to avoid an infinite loop
-                    .when(cart -> cart.topic().size() > 1 && cart.prices().size() == 0)
+            // we need an extra terminal operation to avoid an infinite loop
+            final var reducedPrice = Rule.<Cart>when(cart -> cart.topic().size() > 1 && cart.prices().size() == 0)
                     .then(cart -> cart.prices().add(new Price(TEST_PRODUCT, 75 * cart.topic().size())));
             // the order is no longer important
             rules = Set.of(standardPrice, reducedPrice);


### PR DESCRIPTION
This attribute never served any functionality within the rule engine itself, yet it was a mandatory parameter for all newly created rules. Projects that rely on the human-readable 'name' attribute should consider better names for their variables/parameters instead.

**THIS IS A BREAKING CHANGE**